### PR TITLE
Remove profile tag from credentials file and script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ To use aws-role, you need to have your AWS configuration file specified in your 
     aws_access_key_id = XXXXXXXXXXXXXXXx
     aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-    [profile customer1]
+    [customer1]
     region = us-east-1
 
-    [profile customer2]
+    [customer2]
     region = us-east-1
 
 Now, to access the customer1 profile, I run:

--- a/aws-role
+++ b/aws-role
@@ -19,7 +19,7 @@ import sys
 if not len(sys.argv) == 2:
     print("Usage: aws-role <rolename>\n\n"
           "An example section of your aws config file:\n"
-          "   [profile tjtest]\n\n"
+          "   [tjtest]\n\n"
           "Credentials for the tjtest profile would be obtained by running:\n\n"
           "   aws-role tjtest\n\n"
           "If this is the first time using the profile, you will be\n"
@@ -45,17 +45,17 @@ if not awsConfig.has_section('default'):
     print("aws config file " + awsConfigFile + " must have a [default] profile")
     exit(1)
 
-if not awsConfig.has_section('profile ' + profile):
-    print("section [profile " + profile + "] does not exist in file" + awsConfigFile + "\n")
+if not awsConfig.has_section(profile):
+    print("section [" + profile + "] does not exist in file" + awsConfigFile + "\n")
     exit(1)
 
-if not awsConfig.has_option('profile ' + profile, 'arn'):
+if not awsConfig.has_option(profile, 'arn'):
     role = raw_input("ARN: ")
-    awsConfig.set('profile ' + profile, 'arn', role)
+    awsConfig.set(profile, 'arn', role)
     with open(awsConfigFile, 'wb') as configfile:
-	awsConfig.write(configfile)
+  awsConfig.write(configfile)
 else:
-    role = awsConfig.get('profile ' + profile, 'arn')
+    role = awsConfig.get(profile, 'arn')
 
 #Run aws commandline tool to get STS credentials
 if os.path.isfile("/usr/local/bin/aws"):
@@ -70,9 +70,9 @@ else:
 awsJSON = json.loads(awsReq.communicate()[0])
 
 #Set the required configfile options to activate the profile
-awsConfig.set('profile ' + profile, 'aws_secret_access_key', awsJSON['Credentials']['SecretAccessKey'])
-awsConfig.set('profile ' + profile, 'aws_security_token', awsJSON['Credentials']['SessionToken'])
-awsConfig.set('profile ' + profile, 'aws_access_key_id', awsJSON['Credentials']['AccessKeyId'])
+awsConfig.set(profile, 'aws_secret_access_key', awsJSON['Credentials']['SecretAccessKey'])
+awsConfig.set(profile, 'aws_security_token', awsJSON['Credentials']['SessionToken'])
+awsConfig.set(profile, 'aws_access_key_id', awsJSON['Credentials']['AccessKeyId'])
 with open(awsConfigFile, 'wb') as configfile:
     awsConfig.write(configfile)
 

--- a/aws-role
+++ b/aws-role
@@ -53,7 +53,7 @@ if not awsConfig.has_option(profile, 'arn'):
     role = raw_input("ARN: ")
     awsConfig.set(profile, 'arn', role)
     with open(awsConfigFile, 'wb') as configfile:
-  awsConfig.write(configfile)
+        awsConfig.write(configfile)
 else:
     role = awsConfig.get(profile, 'arn')
 


### PR DESCRIPTION
In order to turn this script compatible with AWS tools (aws and eb cli) and in line with official documentation we must remove "profile" tag from all scripts to avoid changes on the section name standard in credentials file.

Official example here:
http://docs.aws.amazon.com/aws-sdk-php/guide/latest/credentials.html#credential-profiles
